### PR TITLE
Fix text overflow in user and bot messages

### DIFF
--- a/src/assets/scss/_components/_bot-message.scss
+++ b/src/assets/scss/_components/_bot-message.scss
@@ -1,10 +1,12 @@
 @use '../_utils/utils' as *;
 
 .docsbot-chat-bot-message {
-	@include bubble-message('left', $color-secondary-400, $color-neutral-100);
-	word-wrap: break-word;
-	overflow-wrap: break-word;
-	word-break: break-word;
+        @include bubble-message('left', $color-secondary-400, $color-neutral-100);
+
+        // Ensure long text does not overflow the bubble
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        word-break: break-word;
 
 	// Handle text alignment based on content direction
 	span[dir="auto"] {

--- a/src/assets/scss/_components/_user-message.scss
+++ b/src/assets/scss/_components/_user-message.scss
@@ -1,11 +1,16 @@
 @use '../_utils/utils' as *;
 
 .docsbot-user-chat-message {
-	@include bubble-message(
-		'right',
-		var(--docsbot-user--bg, $color-primary-200),
-		var(--docsbot-user--color, $color-neutral-100)
-	);
+        @include bubble-message(
+                'right',
+                var(--docsbot-user--bg, $color-primary-200),
+                var(--docsbot-user--color, $color-neutral-100)
+        );
+
+        // Ensure long text does not overflow the bubble
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        word-break: break-word;
 
 	// Handle text alignment based on content direction
 	span[dir="auto"] {


### PR DESCRIPTION
## Summary
- ensure long text wraps correctly in user and bot chat message bubbles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a4e8556fc832bac4a3a1429edee2f