### PR TITLE
Enable helper APIs in embedded mode

### DIFF
--- a/src/components/embeddableWidget/EmbeddableWidget.jsx
+++ b/src/components/embeddableWidget/EmbeddableWidget.jsx
@@ -10,12 +10,17 @@ export default class EmbeddableWidget {
   static el;
   static teamId;
   static botId;
+  static isEmbedded = false;
 
   static isChatbotOpen = false;
 
   static open() {
     return new Promise((resolve) => {
       this.isChatbotOpen = true;
+      if (this.isEmbedded) {
+        resolve(true);
+        return;
+      }
       Emitter.emit("docsbot_open");
       Emitter.once("docsbot_open_complete", resolve);
     });
@@ -24,6 +29,10 @@ export default class EmbeddableWidget {
   static close() {
     return new Promise((resolve) => {
       this.isChatbotOpen = false;
+      if (this.isEmbedded) {
+        resolve(true);
+        return;
+      }
       Emitter.emit("docsbot_close");
       Emitter.once("docsbot_close_complete", resolve);
     });
@@ -32,6 +41,10 @@ export default class EmbeddableWidget {
   static toggle() {
     return new Promise((resolve) => {
       this.isChatbotOpen = !this.isChatbotOpen;
+      if (this.isEmbedded) {
+        resolve(true);
+        return;
+      }
       Emitter.emit("docsbot_toggle", { isChatbotOpen: this.isChatbotOpen });
       Emitter.once("docsbot_toggle_complete", resolve);
     });
@@ -46,7 +59,9 @@ export default class EmbeddableWidget {
       }
 
       if (send) {
-        await this.open();
+        if (!this.isEmbedded) {
+          await this.open();
+        }
       }
 
       Emitter.emit("docsbot_add_user_message", { message, send });
@@ -75,10 +90,11 @@ export default class EmbeddableWidget {
         this.teamId = teamId;
         this.botId = botId;
       }
-      
+
       const embeddedChatElement = document.getElementById(
         "docsbot-widget-embed"
       );
+      this.isEmbedded = !!embeddedChatElement;
       const component = (
         <ConfigProvider {...props}>
           {embeddedChatElement ? (


### PR DESCRIPTION
## Summary
- support embedded widget detection in `EmbeddableWidget`
- skip open/close/toggle actions when already embedded
- allow `addUserMessage` to work in embedded mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a4ec8e67c832bb34b27096bf68f9f