### PR TITLE
Blur mobile input while generating

### DIFF
--- a/src/components/botChatMessage/BotChatMessage.jsx
+++ b/src/components/botChatMessage/BotChatMessage.jsx
@@ -8,13 +8,14 @@ import { scrollToBottom, getHighlightJs } from '../../utils/utils';
 import clsx from 'clsx';
 
 export const BotChatMessage = ({
-	payload,
-	messageBoxRef,
-	fetchAnswer,
-	chatContainerRef,
-	inputRef
+        payload,
+        messageBoxRef,
+        fetchAnswer,
+        chatContainerRef,
+        inputRef
 }) => {
-	const [rating, setRating] = useState(payload.rating || 0);
+        const [rating, setRating] = useState(payload.rating || 0);
+        const mediaMatch = window.matchMedia('(min-width: 480px)');
 	const [ratingSubmitted, setRatingSubmitted] = useState(false);
 	const {
 		teamId,
@@ -186,11 +187,15 @@ export const BotChatMessage = ({
 				}
 			}
 
-			// Scroll to bottom and focus input after rating
-			scrollToBottom(chatContainerRef);
-			if (inputRef?.current) {
-				inputRef.current.focus();
-			}
+                        // Scroll to bottom and adjust input focus after rating
+                        scrollToBottom(chatContainerRef);
+                        if (inputRef?.current) {
+                                if (mediaMatch.matches) {
+                                        inputRef.current.focus();
+                                } else {
+                                        inputRef.current.blur();
+                                }
+                        }
 
 			const response = await fetch(apiUrl, {
 				method: 'PUT',
@@ -503,12 +508,16 @@ export const BotChatMessage = ({
 											}
 										});
 										fetchAnswer(message);
-										// Scroll to bottom and focus input after clicking no
-										scrollToBottom(chatContainerRef);
-										if (inputRef?.current) {
-											inputRef.current.focus();
-										}
-									}}
+                                                                                // Scroll to bottom and adjust input focus after clicking no
+                                                                                scrollToBottom(chatContainerRef);
+                                                                                if (inputRef?.current) {
+                                                                                        if (mediaMatch.matches) {
+                                                                                                inputRef.current.focus();
+                                                                                        } else {
+                                                                                                inputRef.current.blur();
+                                                                                        }
+                                                                                }
+                                                                        }}
 									className=""
 								>
 									<span dir="auto" aria-hidden="true">

--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -841,32 +841,42 @@ export const Chatbot = ({ isOpen, setIsOpen, isEmbeddedBox }) => {
 				? selectedImages.map((img) => img.thumbnailUrl)
 				: undefined;
 
-		dispatch({
-			type: 'add_message',
-			payload: {
-				variant: 'user',
-				message: chatInput,
-				loading: false,
-				timestamp: Date.now(),
-				imageUrls: historyImageUrls
-			}
-		});
+                dispatch({
+                        type: 'add_message',
+                        payload: {
+                                variant: 'user',
+                                message: chatInput,
+                                loading: false,
+                                timestamp: Date.now(),
+                                imageUrls: historyImageUrls
+                        }
+                });
 
-		// Add full-size image_urls to the API request if image upload is enabled
-		fetchAnswer(chatInput, useImageUpload ? imageUrls : []);
+                // Add full-size image_urls to the API request if image upload is enabled
+                fetchAnswer(chatInput, useImageUpload ? imageUrls : []);
 
-		// Clear the input and images after sending
-		setChatInput('');
-		setSelectedImages([]);
-		setImageUrls([]);
+                // Clear the input and images after sending
+                setChatInput('');
+                setSelectedImages([]);
+                setImageUrls([]);
 
-		// Wait for DOM update, then scroll
-		setTimeout(() => {
-			scrollToBottom(ref);
-		}, 0);
+                // Wait for DOM update, then scroll
+                setTimeout(() => {
+                        scrollToBottom(ref);
+                }, 0);
 
-		inputRef.current.focus();
-	}
+                if (mediaMatch.matches) {
+                        inputRef.current.focus();
+                } else {
+                        inputRef.current.blur();
+                }
+        }
+
+        useEffect(() => {
+                if (!mediaMatch.matches && isFetching && inputRef.current) {
+                        inputRef.current.blur();
+                }
+        }, [isFetching]);
 
 	useEffect(() => {
 		const root = document.documentElement;
@@ -1201,14 +1211,18 @@ export const Chatbot = ({ isOpen, setIsOpen, isEmbeddedBox }) => {
 																	Date.now()
 															}
 														});
-														fetchAnswer(question);
-														setChatInput('');
-														inputRef.current.focus();
-													}}
-													className="docsbot-chat-suggested-questions-button"
-												>
-													{question}
-												</button>
+                                                fetchAnswer(question);
+                                                setChatInput('');
+                                                if (mediaMatch.matches) {
+                                                        inputRef.current.focus();
+                                                } else {
+                                                        inputRef.current.blur();
+                                                }
+                                                }}
+                                                className="docsbot-chat-suggested-questions-button"
+                                        >
+                                                {question}
+                                        </button>
 											);
 										})}
 									</div>


### PR DESCRIPTION
## Summary
- Blur chat input on small screens while responses stream to prevent mobile keyboard from covering messages
- Conditional focus/blur handling for suggested questions and feedback interactions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893e8dbdf70832bad13bc695d78bfbc