### PR TITLE
feat: add configurable suggested question count

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,6 @@ Embeddable chat widget to integrate with DocsBot.ai
 
 Full documentation can be found at https://docsbot.ai/docs/embeddable-chat-widget
 
-### Suggested questions
-
-By default the widget displays up to three random suggested questions from your bot's training data. You can override this amount by passing `suggestedQuestions` in the embed options:
-
-```html
-<script>
-DocsBotAI.init({
-  id: "TEAM/BOT",
-  options: {
-    suggestedQuestions: 4 // show four suggestions instead of three
-  }
-});
-</script>
-```
-
 ## Development
 
 - `npm install` to install dependencies.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ Embeddable chat widget to integrate with DocsBot.ai
 
 Full documentation can be found at https://docsbot.ai/docs/embeddable-chat-widget
 
+### Suggested questions
+
+By default the widget displays up to three random suggested questions from your bot's training data. You can override this amount by passing `suggestedQuestions` in the embed options:
+
+```html
+<script>
+DocsBotAI.init({
+  id: "TEAM/BOT",
+  options: {
+    suggestedQuestions: 4 // show four suggestions instead of three
+  }
+});
+</script>
+```
+
 ## Development
 
 - `npm install` to install dependencies.

--- a/public/index.html
+++ b/public/index.html
@@ -101,6 +101,7 @@
           //color: "#0891b8",
           //botIcon: "https://webstockreview.net/images/user-icon-png-4.png",
           //icon: "http://clipart-library.com/new_gallery/150581_white-question-mark-png.png",
+          //suggestedQuestions: 4, // override number of random suggested questions (default 3)
           //showButtonLabel: true, // Show the button text label or not.
           logo: "https://docsbot.ai/branding/docsbot-logo-white.png",
           //headerAlignment: "left",

--- a/src/components/configContext/ConfigContext.jsx
+++ b/src/components/configContext/ConfigContext.jsx
@@ -10,11 +10,11 @@ export function useConfig() {
   return context;
 }
 
-const grabQuestions = (questions) => {
-  // grab at most 3 unique questions from the bot
+const grabQuestions = (questions, limit = 3) => {
+  // grab at most `limit` unique questions from the bot
   if (questions) {
     const randomQuestions = []
-    const questionsLimit = questions.length > 3 ? 3 : questions.length
+    const questionsLimit = questions.length > limit ? limit : questions.length
 
     for (let i = 0; i < questionsLimit; i++) {
       const randomIndex = Math.floor(Math.random() * questions.length)
@@ -62,7 +62,7 @@ export function ConfigProvider(props = {}) {
         .then((response) => response.json())
         .then((data) => {
           if (data.questions) {
-            data.questions = grabQuestions(data.questions) // limit the number of questions
+            data.questions = grabQuestions(data.questions, options?.suggestedQuestions) // limit the number of questions
           } else {
             data.questions = []
           }


### PR DESCRIPTION
## Summary
- allow overriding the number of random suggested questions via `suggestedQuestions` option
- document new `suggestedQuestions` option in README and example embed code

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f9855684832bab879f4f2716ceb4