### PR TITLE
Fix image upload re-selection after removing attachment

### DIFF
--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -424,6 +424,8 @@ const removeExistingSchedulerEmbeds = (
 		if (!useImageUpload) return;
 		const files = Array.from(e.target.files);
 		processImageFiles(files);
+		// Allow selecting the same file again after removing it.
+		e.target.value = '';
 	};
 
 	const processImageFiles = (files) => {
@@ -529,6 +531,8 @@ const removeExistingSchedulerEmbeds = (
 
 	const triggerFileInput = () => {
 		if (!useImageUpload) return;
+		// Ensure browser dispatches `change` even if the same file is selected.
+		fileInputRef.current.value = '';
 		fileInputRef.current.click();
 	};
 


### PR DESCRIPTION
### Motivation
- Users reported that selecting the same image after removing it from the chat preview does not re-add the image because the file input does not emit a new `change` event when its value is unchanged. 
- The change aims to ensure consistent browser behavior for repeated selections of the same file in the embedded chat widget.

### Description
- In `src/components/chatbot/Chatbot.jsx` clear the hidden file input value at the end of `handleImageSelect` so the same file can be selected again. 
- Also reset `fileInputRef.current.value` before calling `click()` in `triggerFileInput` so opening the picker guarantees a subsequent `change` event even when choosing the same file. 
- These edits are local to the chat file attachment flow and do not alter limits or image processing logic.

### Testing
- Ran `npm run test:labels` which completed successfully with all tests passing. 
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1317e74c832b9595c9ad44829f05)