### PR TITLE
Preserve whitespace and line breaks in user chat messages

### DIFF
--- a/src/assets/scss/_components/_user-message.scss
+++ b/src/assets/scss/_components/_user-message.scss
@@ -19,6 +19,8 @@
 		display: block;
 		width: 100%;
 		white-space: pre-wrap;
+		line-break: strict;
+		overflow-wrap: anywhere;
 	}
 
 	p {

--- a/src/assets/scss/_components/_user-message.scss
+++ b/src/assets/scss/_components/_user-message.scss
@@ -18,6 +18,7 @@
 		unicode-bidi: plaintext;
 		display: block;
 		width: 100%;
+		white-space: pre-wrap;
 	}
 
 	p {


### PR DESCRIPTION
### Motivation
- Ensure user-entered whitespace and line breaks are preserved in chat message bubbles so multiline and preformatted text does not get collapsed or lose line breaks.

### Description
- Add `white-space: pre-wrap;` to `span[dir='auto']` inside `.docsbot-user-chat-message` in `_user-message.scss` to preserve whitespace and wrap long lines.

### Testing
- Ran `npm run build` to verify CSS compiles and `yarn test` unit suite; the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b94ce3b0832ba33177bbef024b92)