### PR TITLE
Improve wrapping and line-break behavior for user chat message spans

### DIFF
--- a/src/assets/scss/_components/_user-message.scss
+++ b/src/assets/scss/_components/_user-message.scss
@@ -18,6 +18,9 @@
 		unicode-bidi: plaintext;
 		display: block;
 		width: 100%;
+		white-space: pre-wrap;
+		line-break: strict;
+		overflow-wrap: anywhere;
 	}
 
 	p {


### PR DESCRIPTION
### Motivation
- Prevent user message text from overflowing chat bubbles and ensure preserved whitespace and correct line breaking for `span[dir='auto']` content.

### Description
- Add `white-space: pre-wrap`, `line-break: strict`, and `overflow-wrap: anywhere` to `span[dir='auto']` inside `.docsbot-user-chat-message` in `_user-message.scss` to improve wrapping and preserve line breaks.

### Testing
- Ran CSS linting and existing frontend tests locally (`stylelint` and project unit/visual tests) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b94ce3b0832ba33177bbef024b92)