### PR TITLE
Handle embedded auto-height scroll spacing

### DIFF
--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -828,7 +828,11 @@ const removeExistingSchedulerEmbeds = (
 		const rootNode = ref.current.getRootNode?.();
 		const host = rootNode?.host;
 		if (!(host instanceof window.HTMLElement)) return false;
-		return host.style.height.trim().toLowerCase() === 'auto';
+		const embedHost =
+			host.id === 'docsbot-widget-embed'
+				? host
+				: host.closest('#docsbot-widget-embed') ?? host;
+		return embedHost.style.height.trim().toLowerCase() === 'auto';
 	};
 
 	const scrollMessageToTopAfterRender = (messageId) => {

--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -823,9 +823,16 @@ const removeExistingSchedulerEmbeds = (
 		void startAudioRecording();
 	};
 
+	const isEmbeddedAutoHeightHost = () => {
+		if (!isEmbeddedBox || !ref.current) return false;
+		const rootNode = ref.current.getRootNode?.();
+		const host = rootNode?.host;
+		if (!(host instanceof window.HTMLElement)) return false;
+		return host.style.height.trim().toLowerCase() === 'auto';
+	};
+
 	const scrollMessageToTopAfterRender = (messageId) => {
-		anchoredTopScrollClientHeightRef.current =
-			isEmbeddedBox && ref.current ? ref.current.clientHeight : null;
+		anchoredTopScrollClientHeightRef.current = null;
 		setAnchoredTopScrollMessageId(messageId);
 		setPendingTopScrollMessageId(messageId);
 	};
@@ -2255,6 +2262,16 @@ const removeExistingSchedulerEmbeds = (
 			const container = ref.current;
 			const messageEl = messageRef?.current;
 			if (container && messageEl) {
+				const shouldUseBottomSpacer =
+					!isEmbeddedBox || !isEmbeddedAutoHeightHost();
+				if (
+					isEmbeddedBox &&
+					shouldUseBottomSpacer &&
+					anchoredTopScrollClientHeightRef.current === null
+				) {
+					anchoredTopScrollClientHeightRef.current =
+						container.clientHeight;
+				}
 				const containerRect = container.getBoundingClientRect();
 				const messageRect = messageEl.getBoundingClientRect();
 				const targetScrollTop = Math.max(
@@ -2273,14 +2290,16 @@ const removeExistingSchedulerEmbeds = (
 						: container.clientHeight;
 				const neededSpacerHeight = Math.max(
 					0,
-					Math.min(
-						effectiveClientHeight,
-						Math.ceil(
-							targetScrollTop +
-								effectiveClientHeight -
-								scrollHeightWithoutSpacer
-						)
-					)
+					shouldUseBottomSpacer
+						? Math.min(
+								effectiveClientHeight,
+								Math.ceil(
+									targetScrollTop +
+										effectiveClientHeight -
+										scrollHeightWithoutSpacer
+								)
+							)
+						: 0
 				);
 
 				if (neededSpacerHeight !== bottomScrollSpacerHeight) {


### PR DESCRIPTION
## Summary
- skip the temporary bottom spacer when embedded hosts use inline height:auto, preventing lingering blank space after submitted messages
- measure fixed-height embedded viewport height after the send render settles, so multiline inputs or image previews collapsing do not stale the spacer math

## Testing
- npm run test:labels
- npm run a11y:lint