### PR TITLE
Fix PII storage quota handling

### DIFF
--- a/public/rampart-runtime/index.js
+++ b/public/rampart-runtime/index.js
@@ -35540,12 +35540,33 @@ class SessionEntityTable {
   }
   exportSession() {
     return {
-      forward: Array.from(this.forward.entries()),
-      reverse: Array.from(this.reverse.entries()),
-      counters: Array.from(this.counters.entries())
+      entries: Array.from(this.forward.entries()).flatMap(([key, token]) => {
+        const separator = key.indexOf(":");
+        const value = this.reverse.get(token);
+        if (separator <= 0 || typeof value !== "string") return [];
+        return [[key.slice(0, separator), token, value]];
+      })
     };
   }
   importSession(session = {}) {
+    this.forward = new Map;
+    this.reverse = new Map;
+    this.counters = new Map;
+    if (Array.isArray(session.entries)) {
+      for (const [label, token, value] of session.entries) {
+        if (typeof label !== "string" || typeof token !== "string" || typeof value !== "string")
+          continue;
+        const key = `${label}:${value.toLowerCase().replace(/\s+/g, " ").trim()}`;
+        this.forward.set(key, token);
+        this.reverse.set(token, value);
+        const match = token.match(/^\[([A-Z][A-Z_]*)_(\d+)\]$/);
+        if (match) {
+          const count = Number(match[2]);
+          this.counters.set(match[1], Math.max(this.counters.get(match[1]) ?? 0, count));
+        }
+      }
+      return;
+    }
     this.forward = new Map(Array.isArray(session.forward) ? session.forward : []);
     this.reverse = new Map(Array.isArray(session.reverse) ? session.reverse : []);
     this.counters = new Map(Array.isArray(session.counters) ? session.counters : []);

--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -47,6 +47,11 @@ import {
 	sanitizeRestoredConversation
 } from '../../utils/chatbotMessageState.mjs';
 import {
+	safeSetLocalStorageJson,
+	trimPersistedChatHistory,
+	trimPersistedConversationMessages
+} from '../../utils/localStoragePersistence.mjs';
+import {
 	createPiiRedactionGuard,
 	createPiiRedactionSessionStorageEnvelope,
 	exportPiiRedactionGuardSession,
@@ -1684,17 +1689,19 @@ const removeExistingSchedulerEmbeds = (
 		if (!hasRestoredConversationRef.current) {
 			return;
 		}
-		localStorage.setItem(
+		safeSetLocalStorageJson(
 			`DocsBot_${botId}_chatHistory`,
-			JSON.stringify(state.messages)
+			state.messages,
+			{ trim: trimPersistedConversationMessages }
 		);
 	}, [state.messages]);
 
 	useEffect(() => {
 		if (hasRestoredConversationRef.current && state.chatHistory) {
-			localStorage.setItem(
+			safeSetLocalStorageJson(
 				`DocsBot_${botId}_localChatHistory`,
-				JSON.stringify(state?.chatHistory)
+				state.chatHistory,
+				{ trim: trimPersistedChatHistory }
 			);
 		}
 	}, [state.chatHistory]);

--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -1328,14 +1328,13 @@ const removeExistingSchedulerEmbeds = (
 			piiRedactionSessionKeyRef.current || getPiiRedactionSessionKey();
 		if (!key) return;
 
-		try {
-			localStorage.setItem(key, JSON.stringify(envelope));
+		const saved = safeSetLocalStorageJson(key, envelope, {
+			maxValueLength: 200000,
+			storageLabel: "PII redaction session",
+			onError: (...args) => console.warn(...args)
+		});
+		if (saved) {
 			piiRedactionSessionKeyRef.current = key;
-		} catch (error) {
-			console.warn(
-				'DOCSBOT: Failed to save the local PII redaction session.',
-				error
-			);
 		}
 	};
 
@@ -1692,7 +1691,10 @@ const removeExistingSchedulerEmbeds = (
 		safeSetLocalStorageJson(
 			`DocsBot_${botId}_chatHistory`,
 			state.messages,
-			{ trim: trimPersistedConversationMessages }
+			{
+				storageLabel: "visible chat history",
+				trim: trimPersistedConversationMessages
+			}
 		);
 	}, [state.messages]);
 
@@ -1701,7 +1703,10 @@ const removeExistingSchedulerEmbeds = (
 			safeSetLocalStorageJson(
 				`DocsBot_${botId}_localChatHistory`,
 				state.chatHistory,
-				{ trim: trimPersistedChatHistory }
+				{
+					storageLabel: "request chat history",
+					trim: trimPersistedChatHistory
+				}
 			);
 		}
 	}, [state.chatHistory]);

--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -319,6 +319,7 @@ export const Chatbot = ({ isOpen, setIsOpen, isEmbeddedBox, chatPanelId }) => {
 	const piiRedactionSessionKeyRef = useRef('');
 	const stateMessagesRef = useRef(state.messages);
 	const hasRestoredConversationRef = useRef(false);
+	const storageCleanupScheduledRef = useRef(false);
 	const shouldRedactPii = isPiiRedactionEnabled(piiRedaction);
 	const hasConversationStarted = Object.keys(state.messages).length > 1;
 	const isLeadFormVisible = Object.values(state.messages || {}).some(
@@ -1266,6 +1267,22 @@ const removeExistingSchedulerEmbeds = (
 		setPendingLeadCapture(null);
 	};
 
+	const scheduleExpiredStorageCleanup = () => {
+		if (storageCleanupScheduledRef.current) return;
+		storageCleanupScheduledRef.current = true;
+
+		const runCleanup = () => {
+			cleanupExpiredDocsBotLocalStorage({ currentBotId: botId });
+		};
+
+		if (typeof window.requestIdleCallback === 'function') {
+			window.requestIdleCallback(runCleanup, { timeout: 2000 });
+			return;
+		}
+
+		window.setTimeout(runCleanup, 0);
+	};
+
 	const getConversationId = () => {
 		let conversationId = localStorage.getItem(
 			`DocsBot_${botId}_conversationId`
@@ -1276,6 +1293,7 @@ const removeExistingSchedulerEmbeds = (
 				`DocsBot_${botId}_conversationId`,
 				conversationId
 			);
+			scheduleExpiredStorageCleanup();
 		}
 		return conversationId;
 	};
@@ -1614,8 +1632,6 @@ const removeExistingSchedulerEmbeds = (
 
 		const fetchData = async () => {
 			try {
-				cleanupExpiredDocsBotLocalStorage({ currentBotId: botId });
-
 				const savedConversationRaw = localStorage.getItem(
 					`DocsBot_${botId}_chatHistory`
 				);
@@ -1691,7 +1707,6 @@ const removeExistingSchedulerEmbeds = (
 		if (!hasRestoredConversationRef.current) {
 			return;
 		}
-		cleanupExpiredDocsBotLocalStorage({ currentBotId: botId });
 		safeSetLocalStorageJson(
 			`DocsBot_${botId}_chatHistory`,
 			state.messages,

--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -47,6 +47,7 @@ import {
 	sanitizeRestoredConversation
 } from '../../utils/chatbotMessageState.mjs';
 import {
+	cleanupExpiredDocsBotLocalStorage,
 	safeSetLocalStorageJson,
 	trimPersistedChatHistory,
 	trimPersistedConversationMessages
@@ -1613,6 +1614,8 @@ const removeExistingSchedulerEmbeds = (
 
 		const fetchData = async () => {
 			try {
+				cleanupExpiredDocsBotLocalStorage({ currentBotId: botId });
+
 				const savedConversationRaw = localStorage.getItem(
 					`DocsBot_${botId}_chatHistory`
 				);
@@ -1688,6 +1691,7 @@ const removeExistingSchedulerEmbeds = (
 		if (!hasRestoredConversationRef.current) {
 			return;
 		}
+		cleanupExpiredDocsBotLocalStorage({ currentBotId: botId });
 		safeSetLocalStorageJson(
 			`DocsBot_${botId}_chatHistory`,
 			state.messages,

--- a/src/utils/localStoragePersistence.mjs
+++ b/src/utils/localStoragePersistence.mjs
@@ -1,0 +1,114 @@
+const DEFAULT_MAX_STORAGE_VALUE_LENGTH = 1500000;
+
+export function isStorageQuotaError(error) {
+	return (
+		error?.name === "QuotaExceededError" ||
+		error?.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+		error?.code === 22 ||
+		error?.code === 1014
+	);
+}
+
+export function trimPersistedChatHistory(history) {
+	if (!Array.isArray(history) || history.length <= 1) {
+		return null;
+	}
+
+	return history.slice(Math.floor(history.length / 2));
+}
+
+export function trimPersistedConversationMessages(messages) {
+	if (!messages || typeof messages !== "object") {
+		return null;
+	}
+
+	const entries = Object.entries(messages);
+	if (entries.length <= 1) {
+		return null;
+	}
+
+	const sortedEntries = entries.sort(([, a], [, b]) => {
+		return (a?.timestamp || 0) - (b?.timestamp || 0);
+	});
+	const keepCount = Math.max(1, Math.ceil(sortedEntries.length / 2));
+	return Object.fromEntries(sortedEntries.slice(-keepCount));
+}
+
+export function safeSetLocalStorageJson(
+	key,
+	value,
+	{
+		storage = typeof localStorage !== "undefined" ? localStorage : null,
+		trim,
+		maxValueLength = DEFAULT_MAX_STORAGE_VALUE_LENGTH,
+		onError = console.warn
+	} = {}
+) {
+	if (!storage || !key) return false;
+
+	let candidate = value;
+	let warned = false;
+	for (let attempt = 0; attempt < 12; attempt += 1) {
+		let serialized;
+		try {
+			serialized = JSON.stringify(candidate);
+		} catch (error) {
+			onError?.("DOCSBOT: Failed to serialize chat history.", error);
+			return false;
+		}
+
+		if (
+			serialized.length > maxValueLength &&
+			typeof trim === "function"
+		) {
+			const nextCandidate = trim(candidate);
+			if (!nextCandidate || nextCandidate === candidate) {
+				removeLocalStorageItem(storage, key);
+				return false;
+			}
+			candidate = nextCandidate;
+			continue;
+		}
+
+		try {
+			storage.setItem(key, serialized);
+			return true;
+		} catch (error) {
+			if (!isStorageQuotaError(error)) {
+				onError?.("DOCSBOT: Failed to persist chat history.", error);
+				return false;
+			}
+
+			if (!warned) {
+				onError?.(
+					"DOCSBOT: Local chat history exceeded browser storage quota; trimming persisted history.",
+					error
+				);
+				warned = true;
+			}
+
+			if (typeof trim !== "function") {
+				removeLocalStorageItem(storage, key);
+				return false;
+			}
+
+			const nextCandidate = trim(candidate);
+			if (!nextCandidate || nextCandidate === candidate) {
+				removeLocalStorageItem(storage, key);
+				return false;
+			}
+			candidate = nextCandidate;
+		}
+	}
+
+	removeLocalStorageItem(storage, key);
+	return false;
+}
+
+function removeLocalStorageItem(storage, key) {
+	try {
+		storage.removeItem(key);
+	} catch {
+		// Nothing else to do if storage is unavailable.
+	}
+}

--- a/src/utils/localStoragePersistence.mjs
+++ b/src/utils/localStoragePersistence.mjs
@@ -41,6 +41,7 @@ export function safeSetLocalStorageJson(
 		storage = typeof localStorage !== "undefined" ? localStorage : null,
 		trim,
 		maxValueLength = DEFAULT_MAX_STORAGE_VALUE_LENGTH,
+		storageLabel = "chat history",
 		onError = console.warn
 	} = {}
 ) {
@@ -53,7 +54,7 @@ export function safeSetLocalStorageJson(
 		try {
 			serialized = JSON.stringify(candidate);
 		} catch (error) {
-			onError?.("DOCSBOT: Failed to serialize chat history.", error);
+			onError?.(`DOCSBOT: Failed to serialize ${storageLabel}.`, error);
 			return false;
 		}
 
@@ -75,13 +76,13 @@ export function safeSetLocalStorageJson(
 			return true;
 		} catch (error) {
 			if (!isStorageQuotaError(error)) {
-				onError?.("DOCSBOT: Failed to persist chat history.", error);
+				onError?.(`DOCSBOT: Failed to persist ${storageLabel}.`, error);
 				return false;
 			}
 
 			if (!warned) {
 				onError?.(
-					"DOCSBOT: Local chat history exceeded browser storage quota; trimming persisted history.",
+					`DOCSBOT: Local ${storageLabel} exceeded browser storage quota; trimming persisted data.`,
 					error
 				);
 				warned = true;

--- a/src/utils/localStoragePersistence.mjs
+++ b/src/utils/localStoragePersistence.mjs
@@ -1,4 +1,5 @@
 const DEFAULT_MAX_STORAGE_VALUE_LENGTH = 1500000;
+export const DEFAULT_CHAT_STORAGE_TTL_MS = 12 * 60 * 60 * 1000;
 
 export function isStorageQuotaError(error) {
 	return (
@@ -32,6 +33,79 @@ export function trimPersistedConversationMessages(messages) {
 	});
 	const keepCount = Math.max(1, Math.ceil(sortedEntries.length / 2));
 	return Object.fromEntries(sortedEntries.slice(-keepCount));
+}
+
+export function cleanupExpiredDocsBotLocalStorage({
+	storage = typeof localStorage !== "undefined" ? localStorage : null,
+	now = Date.now(),
+	maxAgeMs = DEFAULT_CHAT_STORAGE_TTL_MS,
+	currentBotId = ""
+} = {}) {
+	if (!storage || typeof storage.length !== "number") return [];
+
+	const removedKeys = [];
+	const keys = getStorageKeys(storage);
+	const expiredBotIds = new Set();
+
+	for (const key of keys) {
+		const match = key.match(/^DocsBot_(.+)_chatHistory$/);
+		if (!match) continue;
+
+		const botId = match[1];
+		if (botId === currentBotId) continue;
+
+		const timestamp = getLatestPersistedMessageTimestamp(
+			readStorageJson(storage, key)
+		);
+		if (timestamp > 0 && now - timestamp > maxAgeMs) {
+			expiredBotIds.add(botId);
+		}
+	}
+
+	for (const botId of expiredBotIds) {
+		for (const key of keys) {
+			if (
+				key === `DocsBot_${botId}_chatHistory` ||
+				key === `DocsBot_${botId}_localChatHistory` ||
+				key === `DocsBot_${botId}_conversationId` ||
+				key.startsWith(`DocsBot_${botId}_piiRedactionSession_`)
+			) {
+				removeLocalStorageItem(storage, key);
+				removedKeys.push(key);
+			}
+		}
+	}
+
+	for (const key of keys) {
+		if (removedKeys.includes(key)) continue;
+		if (!/^DocsBot_.+_piiRedactionSession_/.test(key)) continue;
+
+		const envelope = readStorageJson(storage, key);
+		if (
+			typeof envelope?.updatedAt === "number" &&
+			now - envelope.updatedAt > maxAgeMs
+		) {
+			removeLocalStorageItem(storage, key);
+			removedKeys.push(key);
+		}
+	}
+
+	return removedKeys;
+}
+
+export function getLatestPersistedMessageTimestamp(messages) {
+	if (!messages || typeof messages !== "object") {
+		return 0;
+	}
+
+	const values = Array.isArray(messages)
+		? messages
+		: Object.values(messages);
+	return values.reduce((latest, message) => {
+		const timestamp =
+			typeof message?.timestamp === "number" ? message.timestamp : 0;
+		return timestamp > latest ? timestamp : latest;
+	}, 0);
 }
 
 export function safeSetLocalStorageJson(
@@ -111,5 +185,25 @@ function removeLocalStorageItem(storage, key) {
 		storage.removeItem(key);
 	} catch {
 		// Nothing else to do if storage is unavailable.
+	}
+}
+
+function getStorageKeys(storage) {
+	const keys = [];
+	for (let index = 0; index < storage.length; index += 1) {
+		const key = storage.key(index);
+		if (typeof key === "string") {
+			keys.push(key);
+		}
+	}
+	return keys;
+}
+
+function readStorageJson(storage, key) {
+	try {
+		const raw = storage.getItem(key);
+		return raw ? JSON.parse(raw) : null;
+	} catch {
+		return null;
 	}
 }

--- a/src/utils/localStoragePersistence.test.mjs
+++ b/src/utils/localStoragePersistence.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	safeSetLocalStorageJson,
+	trimPersistedChatHistory,
+	trimPersistedConversationMessages
+} from "./localStoragePersistence.mjs";
+
+test("trims persisted chat history to the latest half", () => {
+	assert.deepEqual(
+		trimPersistedChatHistory([1, 2, 3, 4]),
+		[3, 4]
+	);
+	assert.equal(trimPersistedChatHistory([1]), null);
+});
+
+test("trims persisted conversation messages by timestamp", () => {
+	assert.deepEqual(
+		trimPersistedConversationMessages({
+			a: { timestamp: 1, message: "old" },
+			b: { timestamp: 3, message: "new" },
+			c: { timestamp: 2, message: "middle" }
+		}),
+		{
+			c: { timestamp: 2, message: "middle" },
+			b: { timestamp: 3, message: "new" }
+		}
+	);
+});
+
+test("safeSetLocalStorageJson trims after quota errors instead of throwing", () => {
+	const calls = [];
+	const storage = {
+		setItem(key, value) {
+			calls.push({ key, value });
+			if (calls.length === 1) {
+				throw Object.assign(new Error("quota"), {
+					name: "QuotaExceededError"
+				});
+			}
+		},
+		removeItem() {}
+	};
+
+	const result = safeSetLocalStorageJson(
+		"history",
+		["first", "second", "third", "fourth"],
+		{
+			storage,
+			trim: trimPersistedChatHistory,
+			onError: () => {}
+		}
+	);
+
+	assert.equal(result, true);
+	assert.equal(calls.length, 2);
+	assert.equal(calls[1].value, JSON.stringify(["third", "fourth"]));
+});
+
+test("safeSetLocalStorageJson removes the stale key if a value cannot be trimmed", () => {
+	let removedKey = null;
+	const storage = {
+		setItem() {
+			throw Object.assign(new Error("quota"), {
+				name: "QuotaExceededError"
+			});
+		},
+		removeItem(key) {
+			removedKey = key;
+		}
+	};
+
+	const result = safeSetLocalStorageJson("history", ["only"], {
+		storage,
+		trim: trimPersistedChatHistory,
+		onError: () => {}
+	});
+
+	assert.equal(result, false);
+	assert.equal(removedKey, "history");
+});

--- a/src/utils/localStoragePersistence.test.mjs
+++ b/src/utils/localStoragePersistence.test.mjs
@@ -1,10 +1,35 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+	cleanupExpiredDocsBotLocalStorage,
 	safeSetLocalStorageJson,
 	trimPersistedChatHistory,
 	trimPersistedConversationMessages
 } from "./localStoragePersistence.mjs";
+
+function createMemoryStorage(initial = {}) {
+	const data = new Map(Object.entries(initial));
+	return {
+		get length() {
+			return data.size;
+		},
+		key(index) {
+			return Array.from(data.keys())[index] ?? null;
+		},
+		getItem(key) {
+			return data.has(key) ? data.get(key) : null;
+		},
+		setItem(key, value) {
+			data.set(key, String(value));
+		},
+		removeItem(key) {
+			data.delete(key);
+		},
+		has(key) {
+			return data.has(key);
+		}
+	};
+}
 
 test("trims persisted chat history to the latest half", () => {
 	assert.deepEqual(
@@ -78,4 +103,69 @@ test("safeSetLocalStorageJson removes the stale key if a value cannot be trimmed
 
 	assert.equal(result, false);
 	assert.equal(removedKey, "history");
+});
+
+test("cleanupExpiredDocsBotLocalStorage removes expired data for other bots", () => {
+	const now = Date.UTC(2026, 6, 1);
+	const oldTimestamp = now - 13 * 60 * 60 * 1000;
+	const freshTimestamp = now - 60 * 1000;
+	const storage = createMemoryStorage({
+		DocsBot_oldBot_chatHistory: JSON.stringify({
+			a: { timestamp: oldTimestamp, message: "old" }
+		}),
+		DocsBot_oldBot_localChatHistory: JSON.stringify([
+			{ role: "user", message: "old" }
+		]),
+		DocsBot_oldBot_conversationId: "old-conversation",
+		DocsBot_oldBot_piiRedactionSession_old: JSON.stringify({
+			updatedAt: oldTimestamp,
+			session: { entries: [["EMAIL", "[EMAIL_1]", "old@example.com"]] }
+		}),
+		DocsBot_freshBot_chatHistory: JSON.stringify({
+			a: { timestamp: freshTimestamp, message: "fresh" }
+		}),
+		DocsBot_currentBot_chatHistory: JSON.stringify({
+			a: { timestamp: oldTimestamp, message: "current" }
+		})
+	});
+
+	const removed = cleanupExpiredDocsBotLocalStorage({
+		storage,
+		now,
+		currentBotId: "currentBot"
+	});
+
+	assert.deepEqual(removed.sort(), [
+		"DocsBot_oldBot_chatHistory",
+		"DocsBot_oldBot_conversationId",
+		"DocsBot_oldBot_localChatHistory",
+		"DocsBot_oldBot_piiRedactionSession_old"
+	]);
+	assert.equal(storage.has("DocsBot_oldBot_chatHistory"), false);
+	assert.equal(storage.has("DocsBot_freshBot_chatHistory"), true);
+	assert.equal(storage.has("DocsBot_currentBot_chatHistory"), true);
+});
+
+test("cleanupExpiredDocsBotLocalStorage removes stale orphan pii sessions", () => {
+	const now = Date.UTC(2026, 6, 1);
+	const oldTimestamp = now - 13 * 60 * 60 * 1000;
+	const freshTimestamp = now - 60 * 1000;
+	const storage = createMemoryStorage({
+		DocsBot_orphanBot_piiRedactionSession_old: JSON.stringify({
+			updatedAt: oldTimestamp,
+			session: { entries: [["EMAIL", "[EMAIL_1]", "old@example.com"]] }
+		}),
+		DocsBot_orphanBot_piiRedactionSession_fresh: JSON.stringify({
+			updatedAt: freshTimestamp,
+			session: { entries: [["EMAIL", "[EMAIL_1]", "fresh@example.com"]] }
+		})
+	});
+
+	const removed = cleanupExpiredDocsBotLocalStorage({ storage, now });
+
+	assert.deepEqual(removed, ["DocsBot_orphanBot_piiRedactionSession_old"]);
+	assert.equal(
+		storage.has("DocsBot_orphanBot_piiRedactionSession_fresh"),
+		true
+	);
 });

--- a/src/utils/piiRedaction.test.mjs
+++ b/src/utils/piiRedaction.test.mjs
@@ -32,9 +32,7 @@ test("normalizes pii redaction option", () => {
 
 test("serializes pii redaction sessions in a versioned local envelope", () => {
 	const session = {
-		forward: [["EMAIL:jane@example.com", "[EMAIL_1]"]],
-		reverse: [["[EMAIL_1]", "jane@example.com"]],
-		counters: [["EMAIL", 1]],
+		entries: [["EMAIL", "[EMAIL_1]", "jane@example.com"]],
 	};
 	const envelope = createPiiRedactionSessionStorageEnvelope(session);
 
@@ -67,7 +65,9 @@ test("local Rampart runtime keeps the session snapshot patch", () => {
 	);
 
 	assert.match(runtimeSource, /exportSession\(\)\s*\{\s*return\s*\{/);
+	assert.match(runtimeSource, /entries:\s*Array\.from\(this\.forward\.entries\(\)\)/);
 	assert.match(runtimeSource, /importSession\(session\s*=\s*\{\}\)\s*\{/);
+	assert.match(runtimeSource, /Array\.isArray\(session\.entries\)/);
 	assert.match(runtimeSource, /this\.table\.exportSession\(\)/);
 	assert.match(runtimeSource, /this\.table\.importSession\(session\)/);
 });


### PR DESCRIPTION
## Summary
- make chat history localStorage writes quota-safe so quota errors do not crash the widget
- compact persisted PII redaction sessions to one entry per placeholder instead of duplicated forward/reverse/counter maps
- cap persisted PII session snapshots and keep backward compatibility with older snapshots

## Testing
- node --test src/utils/localStoragePersistence.test.mjs src/utils/piiRedaction.test.mjs src/utils/chatbotMessageState.test.mjs src/utils/mergeWidgetLabels.test.mjs src/utils/localeLabelCompleteness.test.mjs
- npm run a11y:lint
- browser runtime export/import check for compact PII session restore