### PR TITLE
[codex] Fix wrapped links in bot message lists

### DIFF
--- a/src/assets/scss/_components/_bot-message.scss
+++ b/src/assets/scss/_components/_bot-message.scss
@@ -37,9 +37,8 @@
 	a {
 		color: inherit;
 		font-weight: 500;
-		word-break: break-all;
-		display: inline-block;
-		max-width: 100%;
+		overflow-wrap: anywhere;
+		word-break: normal;
 
 		&:hover {
 			text-decoration: none;


### PR DESCRIPTION
## Summary

Fixes bot message links so long linked text can wrap inline inside ordered and unordered lists instead of dropping below the list marker.

## Root Cause

Bot message anchors were styled as `inline-block` with `max-width: 100%`. When the first content in a list item was a long link, the inline block could not fit next to the marker, so the browser moved it to the next line and left visible blank space after `1.` or the bullet.

## Impact

Long links and linked titles now stay aligned with list markers while still wrapping safely within the message bubble.

## Validation

- `npx sass --no-source-map src/assets/scss/chatbot.scss /tmp/docsbot-chatbot.css`

Did not run `npm run build`, per repo instructions.