### PR TITLE
[codex] Fix Streamdown link buttons in lists

### DIFF
--- a/src/assets/scss/_components/_streamdown.scss
+++ b/src/assets/scss/_components/_streamdown.scss
@@ -13,3 +13,9 @@
 	background-color: #f8fafc; // slate-50
 }
 
+.docsbot-streamdown [data-streamdown='list-item'] [data-streamdown='link'] {
+	display: inline;
+	vertical-align: baseline;
+	overflow-wrap: anywhere;
+	word-break: normal;
+}


### PR DESCRIPTION
## Summary

Fixes Streamdown-rendered link buttons inside list items so long link text aligns with unordered and ordered list markers instead of dropping below the bullet or number.

## Root Cause

The previous list wrapping fix covered normal anchor tags. Streamdown protected links can render as `button[data-streamdown="link"]`, and buttons behave like inline-block content by default. In `list-inside` lists, a long button link can be moved to the next line, leaving the marker alone on the first line.

## Impact

Streamdown link buttons inside bot message list items now render as inline text, keep baseline alignment with the marker, and still wrap safely for long labels.

## Validation

- `/Users/aaron/Documents/docsbot-chat-widget/node_modules/.bin/sass --no-source-map src/assets/scss/chatbot.scss /tmp/docsbot-chatbot-streamdown-pr.css`

Did not run `npm run build`, per repo instructions.