### PR TITLE
Fix voice-disabled input action overlap

### DIFF
--- a/src/assets/scss/_components/_input.scss
+++ b/src/assets/scss/_components/_input.scss
@@ -292,10 +292,14 @@
 	right: 74px;
 }
 
-// Adjust position when submit button is disabled and image upload is the only media button.
-.docsbot-chat-input-form.has-disabled-submit:not(:has(.docsbot-audio-record-btn))
+// Tighten the disabled-state icon spacing while keeping the upload control above
+// the overlapping transparent edge of the disabled submit button.
+.docsbot-chat-input-form.has-disabled-submit:not(
+		:has(.docsbot-audio-record-btn)
+	)
 	.docsbot-image-upload-btn {
 	right: 35px;
+	z-index: 2;
 }
 
 .docsbot-chat-input-form.has-disabled-submit:has(.docsbot-image-upload-btn)

--- a/tests/accessibility/widget.input-layout.spec.mjs
+++ b/tests/accessibility/widget.input-layout.spec.mjs
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+import { installWidgetMocks } from './helpers/widgetMocks.mjs';
+
+const viewports = [
+	{ name: 'desktop', width: 1280, height: 800 },
+	{ name: 'narrow mobile', width: 320, height: 568 }
+];
+
+async function openVoiceDisabledWidget(page) {
+	await page.route('http://127.0.0.1:4173/', async (route) => {
+		const response = await route.fetch();
+		const originalHtml = await response.text();
+		const html = originalHtml
+			.replace('localDev: true', 'localDev: false')
+			.replace('useAudioUpload: true', 'useAudioUpload: false');
+
+		expect(html).not.toBe(originalHtml);
+		await route.fulfill({
+			response,
+			body: html,
+			headers: {
+				...response.headers(),
+				'content-type': 'text/html; charset=utf-8'
+			}
+		});
+	});
+	await installWidgetMocks(page);
+	await page.goto('/');
+
+	const widget = page.locator('#docsbotai-root');
+	await widget.getByRole('button', { name: 'Help' }).click();
+
+	const chatInput = widget.locator('textarea');
+	const imageUpload = widget.getByRole('button', { name: 'Upload image' });
+	const send = widget.getByRole('button', { name: 'Submit' });
+	await expect(imageUpload).toBeVisible();
+	await expect(send).toBeVisible();
+	await expect(
+		widget.getByRole('button', { name: 'Record voice message' })
+	).toHaveCount(0);
+
+	return { chatInput, imageUpload, send };
+}
+
+async function getControlLayout(imageUpload, send) {
+	const imageBox = await imageUpload.boundingBox();
+	const sendBox = await send.boundingBox();
+	const imageIconBox = await imageUpload.locator('svg').boundingBox();
+	const sendIconBox = await send.locator('svg').boundingBox();
+
+	expect(imageBox).not.toBeNull();
+	expect(sendBox).not.toBeNull();
+	expect(imageIconBox).not.toBeNull();
+	expect(sendIconBox).not.toBeNull();
+
+	return { imageBox, sendBox, imageIconBox, sendIconBox };
+}
+
+for (const viewport of viewports) {
+	test(`voice-disabled upload icon stays visible with compact spacing at ${viewport.name} width`, async ({
+		page
+	}) => {
+		await page.setViewportSize(viewport);
+		const { chatInput, imageUpload, send } =
+			await openVoiceDisabledWidget(page);
+
+		await expect(send).toBeDisabled();
+		const disabledLayout = await getControlLayout(imageUpload, send);
+		expect(
+			disabledLayout.imageBox.x +
+				disabledLayout.imageBox.width -
+				disabledLayout.sendBox.x
+		).toBeGreaterThan(0);
+		expect(
+			disabledLayout.imageIconBox.x + disabledLayout.imageIconBox.width
+		).toBeLessThan(disabledLayout.sendIconBox.x);
+		expect(
+			await imageUpload.evaluate(
+				(button, point) => {
+					const target = button
+						.getRootNode()
+						.elementFromPoint(point.x, point.y);
+					return target === button || button.contains(target);
+				},
+				{
+					x: disabledLayout.sendBox.x + 1,
+					y:
+						disabledLayout.imageBox.y +
+						disabledLayout.imageBox.height / 2
+				}
+			)
+		).toBe(true);
+
+		await chatInput.fill('Hello');
+
+		await expect(send).toBeEnabled();
+		const enabledLayout = await getControlLayout(imageUpload, send);
+		expect(
+			enabledLayout.sendBox.x -
+				(enabledLayout.imageBox.x + enabledLayout.imageBox.width)
+		).toBeGreaterThanOrEqual(2);
+		expect(disabledLayout.imageBox.x).toBeGreaterThan(
+			enabledLayout.imageBox.x
+		);
+	});
+}


### PR DESCRIPTION
## Summary

- preserve the compact image-upload position when voice input is disabled and send is inactive
- raise the image-upload control above the overlapping disabled send-button edge so the image icon stays fully visible and clickable
- add focused browser regression coverage for disabled and enabled send states at desktop and narrow-mobile widths

## Root cause

The intentional `right: 35px` compact position makes the upload and disabled send hit boxes overlap by 11px. Both controls previously used the same z-index, and the send button renders later, so its disabled background painted over the right edge of the upload icon.

## Validation

- focused Playwright layout tests: 2 passed at 1280x800 and 320x568
- `npm run test:labels`: 25 passed
- `npm run a11y:lint`: passed
- Prettier and `git diff --check`: passed
- visually verified the intentional 11px hit-box overlap now retains a 9px visible icon gap, with upload above send in the overlap