### PR TITLE
Preserve widget testing flag in chat requests

### DIFF
--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -270,6 +270,7 @@ export const Chatbot = ({ isOpen, setIsOpen, isEmbeddedBox, chatPanelId }) => {
 		useTidyCal,
 		keepFooterVisible,
 		localDev,
+		testing,
 		allowedDomains,
 		linkSafetyEnabled,
 		leadCollect,
@@ -1836,6 +1837,7 @@ const removeExistingSchedulerEmbeds = (
 				tidycal: isTidyCalEnabled,
 				full_source: false,
 				metadata,
+				testing: Boolean(testing),
 				conversationId: getConversationId(),
 				context_items: contextItems || 6,
 				autocut: 2,
@@ -2268,6 +2270,7 @@ const removeExistingSchedulerEmbeds = (
 				markdown: true,
 				history,
 				metadata,
+				testing: Boolean(testing),
 				context_items: contextItems || 6,
 				autocut: 2
 			};

--- a/src/components/configContext/ConfigContext.jsx
+++ b/src/components/configContext/ConfigContext.jsx
@@ -159,6 +159,7 @@ export function ConfigProvider(props = {}) {
           branding,
           allowedDomains: optionsAllowedDomains,
           piiRedaction: optionsPiiRedaction,
+          testing: optionsTesting,
           ...restOptions
         } = options || {};
 
@@ -198,6 +199,7 @@ export function ConfigProvider(props = {}) {
           identify: identify || {},
           signature,
           ...restOptions,
+          testing: optionsTesting === true,
           piiRedaction,
           labels: mergedLabels,
           textDirection,


### PR DESCRIPTION
## Summary
- preserve the Instructions-page testing flag as widget configuration
- forward testing=true in agent and standard chat requests
- prevent test-panel conversations from losing the marker before logging

## Validation
- npm run a11y:lint
- npm run build (passes; existing bundle-size warnings remain)

## Notes
This fixes the widget request path. The dashboard reporting/search paths may still need a separate follow-up so testing traffic is consistently excluded from aggregate reporting and search results retain the testing field.