### PR TITLE
Add clickable Streamdown answer images

### DIFF
--- a/src/assets/scss/_components/_streamdown.scss
+++ b/src/assets/scss/_components/_streamdown.scss
@@ -38,3 +38,124 @@
 	overflow-wrap: anywhere;
 	word-break: normal;
 }
+
+.docsbot-streamdown img[data-streamdown='image'].docsbot-answer-image {
+	display: block;
+	max-width: 100%;
+	height: auto;
+	cursor: zoom-in;
+	outline: 0 solid transparent;
+	transition:
+		box-shadow 140ms ease,
+		transform 140ms ease;
+}
+.docsbot-streamdown img[data-streamdown='image'].docsbot-answer-image:hover {
+	box-shadow: 0 0 0 2px var(--docsbot-border-subtle);
+}
+
+.docsbot-streamdown img[data-streamdown='image'].docsbot-answer-image:focus-visible {
+	box-shadow: 0 0 0 3px var(--docsbot-link-color, var(--docsbot-border));
+}
+
+.docsbot-image-lightbox {
+	position: fixed;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: clamp(16px, 4vw, 48px);
+	box-sizing: border-box;
+	background: rgba(15, 23, 42, 0.82);
+	z-index: 1000001;
+}
+
+.docsbot-image-lightbox-backdrop {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	cursor: default;
+}
+
+.docsbot-image-lightbox-panel {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	max-width: min(100%, 1200px);
+	max-height: 100%;
+	padding: clamp(16px, 3vw, 32px);
+	box-sizing: border-box;
+	border-radius: 14px;
+	background: var(--docsbot-surface-elevated);
+	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.38);
+	z-index: 1;
+}
+
+.docsbot-image-lightbox-image {
+	display: block;
+	max-width: 100%;
+	max-height: min(86vh, 760px);
+	width: auto;
+	height: auto;
+	object-fit: contain;
+	border-radius: 8px;
+}
+
+.docsbot-image-lightbox-close {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	min-height: 36px;
+	padding: 6px 10px;
+	border: 1px solid var(--docsbot-border-subtle);
+	border-radius: 999px;
+	background: var(--docsbot-surface);
+	color: var(--docsbot-text);
+	font: inherit;
+	font-size: 0.8125rem;
+	line-height: 1;
+	cursor: pointer;
+	z-index: 1;
+}
+
+.docsbot-image-lightbox-close span:first-child {
+	font-size: 1.35rem;
+	line-height: 0.7;
+}
+
+.docsbot-image-lightbox-close:hover {
+	background: var(--docsbot-surface-subtle);
+}
+
+.docsbot-image-lightbox-close:focus-visible {
+	outline: 2px solid var(--docsbot-link-color, var(--docsbot-border));
+	outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+	.docsbot-image-lightbox {
+		padding: 12px;
+	}
+
+	.docsbot-image-lightbox-panel {
+		width: 100%;
+		padding: 42px 12px 12px;
+	}
+
+	.docsbot-image-lightbox-image {
+		max-height: 78vh;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.docsbot-streamdown img[data-streamdown='image'].docsbot-answer-image {
+		transition: none;
+	}
+}

--- a/src/components/botChatMessage/BotChatMessage.jsx
+++ b/src/components/botChatMessage/BotChatMessage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, Suspense } from 'react';
+import { useState, useEffect, useRef, useCallback, Suspense } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { Loader } from '../loader/Loader';
 import { useConfig } from '../configContext/ConfigContext';
@@ -27,6 +27,7 @@ import { StripeBilling } from '../stripeBilling/StripeBilling';
 import { CalendlyEmbed } from '../calendlyEmbed/CalendlyEmbed';
 import { CalComEmbed } from '../calComEmbed/CalComEmbed';
 import { TidyCalEmbed } from '../tidyCalEmbed/TidyCalEmbed';
+import { ImageLightbox } from '../imageLightbox/ImageLightbox';
 
 /**
  * Config `labels` keys when agent activity uses configKey (all tools except reasoning).
@@ -331,11 +332,102 @@ export const BotChatMessage = ({
 	const contentRef = useRef(null);
 	const [isSupportLoading, setIsSupportLoading] = useState(false);
 	const [isCopied, setIsCopied] = useState(false);
+	const [lightboxImage, setLightboxImage] = useState(null);
+	const [lightboxTrigger, setLightboxTrigger] = useState(null);
 	const [leadFormValues, setLeadFormValues] = useState({});
 	const [leadFormTouched, setLeadFormTouched] = useState(false);
 	const [voiceEscalationResolved, setVoiceEscalationResolved] =
 		useState(false);
 	const assistantMessagePrefix = `${botName || 'Assistant'}: `;
+
+	const openImageLightbox = useCallback((image, triggerElement) => {
+		setLightboxImage(image);
+		setLightboxTrigger(triggerElement);
+	}, []);
+
+	const closeImageLightbox = useCallback(() => {
+		setLightboxImage(null);
+		setLightboxTrigger(null);
+	}, []);
+
+	useEffect(() => {
+		const contentNode = contentRef.current;
+		if (!contentNode) return undefined;
+
+		const imageSelector = "img[data-streamdown='image']";
+		const removeImageEnhancement = (image) => {
+			image.classList.remove('docsbot-answer-image');
+			image.removeAttribute('role');
+			image.removeAttribute('tabindex');
+			image.removeAttribute('aria-label');
+			delete image.dataset.docsbotClickableImage;
+		};
+
+		const enhanceImages = () => {
+			contentNode.querySelectorAll(imageSelector).forEach((image) => {
+				if (image.closest("a, [data-streamdown='link']")) {
+					removeImageEnhancement(image);
+					return;
+				}
+				image.classList.add('docsbot-answer-image');
+				image.dataset.docsbotClickableImage = 'true';
+				image.setAttribute('role', 'button');
+				image.setAttribute('tabindex', '0');
+				image.setAttribute(
+					'aria-label',
+					image.alt || image.title || image.src
+				);
+			});
+		};
+
+		const getImageFromEvent = (event) => {
+			const target = event.target;
+			return target instanceof Element
+				? target.closest(imageSelector)
+				: null;
+		};
+
+		const handleClick = (event) => {
+			const image = getImageFromEvent(event);
+			if (!image || image.closest("a, [data-streamdown='link']")) return;
+
+			event.preventDefault();
+			event.stopPropagation();
+			openImageLightbox(
+				{
+					src: image.currentSrc || image.src,
+					alt: image.alt,
+					title: image.title
+				},
+				image
+			);
+		};
+
+		const handleKeyDown = (event) => {
+			if (event.key !== 'Enter' && event.key !== ' ') return;
+
+			const image = getImageFromEvent(event);
+			if (!image || image.closest("a, [data-streamdown='link']")) return;
+
+			event.preventDefault();
+			handleClick(event);
+		};
+
+		enhanceImages();
+		const observer = new MutationObserver(enhanceImages);
+		observer.observe(contentNode, { childList: true, subtree: true });
+		contentNode.addEventListener('click', handleClick);
+		contentNode.addEventListener('keydown', handleKeyDown);
+
+		return () => {
+			observer.disconnect();
+			contentNode.removeEventListener('click', handleClick);
+			contentNode.removeEventListener('keydown', handleKeyDown);
+			contentNode.querySelectorAll('[data-docsbot-clickable-image]').forEach(
+				removeImageEnhancement
+			);
+		};
+	}, [openImageLightbox, payload.message, payload.streaming, payload.type]);
 
 	const copyContentToClipboard = async () => {
 		// payload.message contains raw markdown
@@ -877,6 +969,12 @@ export const BotChatMessage = ({
 
 	return (
 		<>
+			<ImageLightbox
+				image={lightboxImage}
+				closeLabel={labels.close}
+				onClose={closeImageLightbox}
+				triggerElement={lightboxTrigger}
+			/>
 			{showMessageChrome ? (
 			<div
 				className={clsx(

--- a/src/components/imageLightbox/ImageLightbox.jsx
+++ b/src/components/imageLightbox/ImageLightbox.jsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from 'react';
+
+export const ImageLightbox = ({
+	image,
+	closeLabel = 'Close',
+	onClose,
+	triggerElement
+}) => {
+	const dialogRef = useRef(null);
+	const closeButtonRef = useRef(null);
+
+	useEffect(() => {
+		if (!image) return undefined;
+
+		const previouslyFocusedElement =
+			triggerElement || document.activeElement;
+		const focusFrame = window.requestAnimationFrame(() => {
+			closeButtonRef.current?.focus();
+		});
+
+		const getFocusableElements = () =>
+			Array.from(
+				dialogRef.current?.querySelectorAll(
+					'button:not([disabled]):not([tabindex="-1"]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				) || []
+			);
+
+		const handleKeyDown = (event) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				event.stopPropagation();
+				onClose();
+				return;
+			}
+
+			if (event.key !== 'Tab') return;
+
+			const focusableElements = getFocusableElements();
+			if (focusableElements.length === 0) {
+				event.preventDefault();
+				closeButtonRef.current?.focus();
+				return;
+			}
+
+			const firstElement = focusableElements[0];
+			const lastElement = focusableElements[focusableElements.length - 1];
+			if (!dialogRef.current?.contains(document.activeElement)) {
+				event.preventDefault();
+				firstElement.focus();
+			} else if (event.shiftKey && document.activeElement === firstElement) {
+				event.preventDefault();
+				lastElement.focus();
+			} else if (
+				!event.shiftKey &&
+				document.activeElement === lastElement
+			) {
+				event.preventDefault();
+				firstElement.focus();
+			}
+		};
+
+		document.addEventListener('keydown', handleKeyDown, true);
+
+		return () => {
+			window.cancelAnimationFrame(focusFrame);
+			document.removeEventListener('keydown', handleKeyDown, true);
+			if (previouslyFocusedElement?.isConnected) {
+				window.requestAnimationFrame(() => {
+					previouslyFocusedElement.focus?.();
+				});
+			}
+		};
+	}, [image, onClose, triggerElement]);
+
+	if (!image) return null;
+
+	return (
+		<div
+			ref={dialogRef}
+			className="docsbot-image-lightbox"
+			role="dialog"
+			aria-modal="true"
+			aria-label={image.alt || image.title || image.src}
+		>
+			<button
+				type="button"
+				className="docsbot-image-lightbox-backdrop"
+				aria-label={closeLabel}
+				tabIndex={-1}
+				onClick={onClose}
+			/>
+			<div className="docsbot-image-lightbox-panel">
+				<button
+					ref={closeButtonRef}
+					type="button"
+					className="docsbot-image-lightbox-close"
+					onClick={onClose}
+				>
+					<span aria-hidden="true">×</span>
+					<span>{closeLabel}</span>
+				</button>
+				<img
+					className="docsbot-image-lightbox-image"
+					src={image.src}
+					alt={image.alt || ''}
+					title={image.title}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/tests/accessibility/helpers/widgetMocks.mjs
+++ b/tests/accessibility/helpers/widgetMocks.mjs
@@ -40,6 +40,54 @@ data: ${JSON.stringify({
 `;
   }
 
+  if (normalizedQuestion.includes("linked image")) {
+    const answer = [
+      "Here is a linked image from the answer.",
+      "",
+      "[![DocsBot linked image](https://example.com/docsbot-answer-demo.svg)](http://127.0.0.1:4173/linked-image-target)",
+    ].join("\n");
+
+    return `event: stream
+data: ${answer.replaceAll("\n", "\nevent: stream\ndata: ")}
+
+event: done
+data: ${JSON.stringify({
+  answer,
+  history: [
+    { role: "user", message: question },
+    { role: "assistant", message: answer },
+  ],
+  id: "answer-linked-image",
+})}
+
+`;
+  }
+
+  if (normalizedQuestion.includes("image")) {
+    const answer = [
+      "Here is the image from the answer.",
+      "",
+      "![DocsBot answer image](https://example.com/docsbot-answer-demo.svg)",
+      "",
+      "The conversation stays here after you close the enlarged view.",
+    ].join("\n");
+
+    return `event: stream
+data: ${answer.replaceAll("\n", "\nevent: stream\ndata: ")}
+
+event: done
+data: ${JSON.stringify({
+  answer,
+  history: [
+    { role: "user", message: question },
+    { role: "assistant", message: answer },
+  ],
+  id: "answer-image",
+})}
+
+`;
+  }
+
   return `event: stream
 data: Here is a mocked answer with a source.
 
@@ -98,6 +146,32 @@ export async function installWidgetMocks(page, widgetConfig = mockWidgetConfig) 
         connection: "keep-alive",
       },
       body: buildAgentSse(body),
+    });
+  });
+
+  await page.route("https://example.com/docsbot-answer-demo.svg", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/svg+xml",
+      body: `<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="background" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#17324d" />
+      <stop offset="1" stop-color="#0e7490" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" rx="28" fill="url(#background)" />
+  <circle cx="790" cy="110" r="120" fill="#67e8f9" opacity=".24" />
+  <circle cx="180" cy="460" r="190" fill="#a7f3d0" opacity=".16" />
+  <rect x="96" y="96" width="768" height="348" rx="22" fill="#f8fafc" opacity=".96" />
+  <rect x="142" y="145" width="300" height="24" rx="12" fill="#0e7490" />
+  <rect x="142" y="202" width="610" height="14" rx="7" fill="#cbd5e1" />
+  <rect x="142" y="232" width="530" height="14" rx="7" fill="#cbd5e1" />
+  <rect x="142" y="290" width="190" height="88" rx="14" fill="#67e8f9" opacity=".75" />
+  <rect x="354" y="290" width="190" height="88" rx="14" fill="#a7f3d0" opacity=".8" />
+  <rect x="566" y="290" width="190" height="88" rx="14" fill="#fde68a" opacity=".8" />
+  <text x="142" y="416" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#17324d">DocsBot answer image</text>
+</svg>`,
     });
   });
 }

--- a/tests/accessibility/widget-answer-images.spec.mjs
+++ b/tests/accessibility/widget-answer-images.spec.mjs
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { installWidgetMocks } from './helpers/widgetMocks.mjs';
+
+async function openImageAnswer(page, question = 'Show me an image') {
+	await installWidgetMocks(page);
+	await page.goto('/?visual=1');
+
+	const widget = page.locator('#docsbotai-root');
+	await widget.getByRole('button', { name: 'Help' }).click();
+
+	const chatInput = widget.locator('textarea');
+	await expect(chatInput).toBeVisible();
+	await chatInput.fill(question);
+	await chatInput.press('Enter');
+
+	const answerImage = widget.getByRole('button', {
+		name: 'DocsBot answer image'
+	});
+	if (!question.includes('linked')) {
+		await expect(answerImage).toBeVisible();
+		await expect(
+			widget.locator(
+				"[data-streamdown='image-wrapper'] button[title='Download image']"
+			)
+		).toBeVisible();
+	}
+
+	return { widget, answerImage };
+}
+
+test('opens and closes an assistant answer image without losing conversation context', async ({
+	page
+}) => {
+	const { widget, answerImage } = await openImageAnswer(page);
+	const conversationText =
+		'The conversation stays here after you close the enlarged view.';
+
+	await answerImage.click();
+
+	const lightbox = widget.getByRole('dialog');
+	await expect(lightbox).toBeVisible();
+	await expect(
+		lightbox.getByRole('img', { name: 'DocsBot answer image' })
+	).toBeVisible();
+	await expect(widget.getByText(conversationText)).toBeVisible();
+	const axeResults = await new AxeBuilder({ page })
+		.include('#docsbotai-root')
+		.analyze();
+	expect(
+		axeResults.violations.filter(
+			(violation) => violation.impact === 'critical'
+		)
+	).toEqual([]);
+	const closeButton = lightbox.locator('.docsbot-image-lightbox-close');
+	await expect(closeButton).toBeFocused();
+	await page.keyboard.press('Tab');
+	await expect(closeButton).toBeFocused();
+	await page.keyboard.press('Shift+Tab');
+	await expect(closeButton).toBeFocused();
+
+	await closeButton.click();
+
+	await expect(lightbox).toBeHidden();
+	await expect(widget.getByText(conversationText)).toBeVisible();
+	await expect(answerImage).toBeFocused();
+});
+
+test('closes an assistant answer image with Escape and keeps the same answer mounted', async ({
+	page
+}) => {
+	const { widget, answerImage } = await openImageAnswer(page);
+
+	await answerImage.click();
+	const lightbox = widget.getByRole('dialog');
+	await expect(lightbox).toBeVisible();
+
+	await page.keyboard.press('Escape');
+
+	await expect(lightbox).toBeHidden();
+	await expect(answerImage).toBeVisible();
+	await expect(answerImage).toBeFocused();
+});
+
+test('keeps linked assistant answer images as native links', async ({ page }) => {
+	const { widget } = await openImageAnswer(page, 'Show me a linked image');
+	const targetUrl = 'http://127.0.0.1:4173/linked-image-target';
+	const linkedImage = widget.locator(
+		"[data-streamdown='link'] img[data-streamdown='image']"
+	);
+
+	await expect(linkedImage).toBeVisible();
+	await expect(linkedImage).not.toHaveAttribute('role', 'button');
+	await expect(linkedImage).not.toHaveAttribute('tabindex', '0');
+	await expect(widget.getByRole('dialog')).toHaveCount(0);
+
+	const popupPromise = page.waitForEvent('popup');
+	await linkedImage.click();
+	const popup = await popupPromise;
+	await expect(popup).toHaveURL(targetUrl);
+	await expect(widget.getByRole('dialog')).toHaveCount(0);
+	await popup.close();
+});


### PR DESCRIPTION
## What changed
- make standalone Streamdown images in assistant answers clickable and open an accessible lightbox
- preserve Streamdown's native image renderer, including its download button and linked-image behavior
- add focus restoration, Escape/backdrop close actions, and focus containment
- add focused browser coverage for opening, closing, context preservation, download control presence, and linked-image navigation

## Why
Assistant answer images were rendered as static content. The widget now supports enlarging standalone images without replacing or losing the current conversation, while linked images retain their existing navigation behavior.

## Validation
- `npm run a11y:lint`
- `npm run test:labels` (25 passed)
- `git diff --check`
- `npx playwright test tests/accessibility/widget-answer-images.spec.mjs --reporter=list` (3 passed)
- Real headed browser demo recorded at `/Users/aaron/Documents/Codex/2026-08-12/cr/outputs/widget-answer-image-lightbox-demo.mp4`

No deployment or publish was performed.