### PR TITLE
Add lead capture DOM event

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ document.addEventListener('docsbot_voice_call_end', (event) => {
 | `docsbot_voice_call_start` | Voice WebRTC data channel opens (connecting UI settles) | `{ conversationId: string \| null }` |
 | `docsbot_voice_call_end` | Caller leaves voice (End call, Back, remote close, etc.) | `{ conversationId: string \| null }` |
 | `docsbot_tool_call` | Tool requested in text chat **or** live voice (same shape) | `{ name: string, data: object \| string \| null }` |
+| `docsbot_lead_capture` | Lead form submission is accepted by the lead capture API | `{ conversationId: string \| null, fields: object, metadata: object }` |
+
+Listen on `document` to trigger analytics after a lead has been saved. `fields`
+contains the values submitted through the lead form. `metadata` contains the
+complete public metadata sent to the lead API, including merged `identify`
+values and the submitted fields.
+
+```js
+document.addEventListener('docsbot_lead_capture', (event) => {
+  console.log('Captured lead fields:', event.detail.fields);
+  console.log('Captured lead metadata:', event.detail.metadata);
+
+  fbq('trackCustom', 'DocsBotLeadCaptured', {
+    conversation_id: event.detail.conversationId,
+  });
+});
+```
+
+Lead fields may contain personal information. Do not send names, email
+addresses, phone numbers, or other prohibited customer data to Meta Pixel.
 
 Finalized caller and agent transcripts are appended to the same canonical
 conversation history as text-chat turns. Voice-mode `customButtonCallback` and

--- a/src/components/chatbot/Chatbot.jsx
+++ b/src/components/chatbot/Chatbot.jsx
@@ -57,6 +57,7 @@ import {
 	trimPersistedChatHistory,
 	trimPersistedConversationMessages
 } from '../../utils/localStoragePersistence.mjs';
+import { dispatchLeadCaptureEvent } from '../../utils/widgetDomEvents.mjs';
 import {
 	mapChatHistoryStrings,
 	mapChatHistoryStringsSync
@@ -1071,7 +1072,7 @@ export const Chatbot = ({ isOpen, setIsOpen, isEmbeddedBox, chatPanelId }) => {
 		return true;
 	};
 
-	const captureLead = async (metadata) => {
+	const captureLead = async (metadata, fields) => {
 		const conversationId = getConversationId();
 		const apiBase = apiBaseUrl;
 		const apiUrl = `${apiBase}/teams/${teamId}/bots/${botId}/conversations/${conversationId}/lead`;
@@ -1095,7 +1096,14 @@ export const Chatbot = ({ isOpen, setIsOpen, isEmbeddedBox, chatPanelId }) => {
 					response.status,
 					response.statusText
 				);
+				return;
 			}
+
+			dispatchLeadCaptureEvent({
+				conversationId,
+				fields,
+				metadata
+			});
 		} catch (err) {
 			console.warn('DOCSBOT: Failed to capture lead', err);
 		}
@@ -1161,7 +1169,7 @@ export const Chatbot = ({ isOpen, setIsOpen, isEmbeddedBox, chatPanelId }) => {
 			pendingLeadCapture || message?.leadContext || null;
 
 		updateIdentity(leadMetadata);
-		void captureLead(leadMetadata);
+		void captureLead(leadMetadata, data.metadata || {});
 
 		if (leadCollect?.mode === 'before_escalation') {
 			setLeadCollected(true);

--- a/src/utils/widgetDomEvents.mjs
+++ b/src/utils/widgetDomEvents.mjs
@@ -1,0 +1,26 @@
+export const LEAD_CAPTURE_EVENT = 'docsbot_lead_capture';
+
+export function dispatchLeadCaptureEvent(
+	{ conversationId, fields = {}, metadata = {} },
+	eventTarget = globalThis.document,
+	CustomEventImpl = globalThis.CustomEvent
+) {
+	if (
+		!eventTarget ||
+		typeof eventTarget.dispatchEvent !== 'function' ||
+		typeof CustomEventImpl !== 'function'
+	) {
+		return false;
+	}
+
+	eventTarget.dispatchEvent(
+		new CustomEventImpl(LEAD_CAPTURE_EVENT, {
+			detail: {
+				conversationId: conversationId || null,
+				fields: { ...fields },
+				metadata: { ...metadata }
+			}
+		})
+	);
+	return true;
+}

--- a/src/utils/widgetDomEvents.test.mjs
+++ b/src/utils/widgetDomEvents.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	dispatchLeadCaptureEvent,
+	LEAD_CAPTURE_EVENT
+} from './widgetDomEvents.mjs';
+
+class FakeCustomEvent {
+	constructor(type, init) {
+		this.type = type;
+		this.detail = init.detail;
+	}
+}
+
+test('dispatchLeadCaptureEvent publishes lead fields and merged metadata', () => {
+	const events = [];
+	const eventTarget = {
+		dispatchEvent(event) {
+			events.push(event);
+		}
+	};
+
+	assert.equal(
+		dispatchLeadCaptureEvent(
+			{
+				conversationId: 'conversation-1',
+				fields: {
+					name: 'Ada Lovelace',
+					email: 'ada@example.com'
+				},
+				metadata: {
+					name: 'Ada Lovelace',
+					email: 'ada@example.com',
+					plan: 'pro'
+				}
+			},
+			eventTarget,
+			FakeCustomEvent
+		),
+		true
+	);
+	assert.equal(events.length, 1);
+	assert.equal(events[0].type, LEAD_CAPTURE_EVENT);
+	assert.deepEqual(events[0].detail, {
+		conversationId: 'conversation-1',
+		fields: {
+			name: 'Ada Lovelace',
+			email: 'ada@example.com'
+		},
+		metadata: {
+			name: 'Ada Lovelace',
+			email: 'ada@example.com',
+			plan: 'pro'
+		}
+	});
+});
+
+test('dispatchLeadCaptureEvent safely skips unavailable DOM APIs', () => {
+	assert.equal(
+		dispatchLeadCaptureEvent(
+			{ conversationId: 'conversation-1' },
+			null,
+			FakeCustomEvent
+		),
+		false
+	);
+	assert.equal(
+		dispatchLeadCaptureEvent({ conversationId: 'conversation-1' }, {}, null),
+		false
+	);
+});


### PR DESCRIPTION
## What changed

- dispatches a new `docsbot_lead_capture` CustomEvent on `document` after the lead capture API returns a successful response
- includes `conversationId`, submitted lead `fields`, and merged public `metadata` in `event.detail`
- keeps signed private JWT metadata out of the browser event
- documents a Meta Pixel custom-event example and warns against forwarding personal lead data

## Why

Embed owners need a reliable frontend conversion signal when a lead is actually saved. Previously, the widget exposed answer, tool, and voice events but no lead-capture event.

## Validation

- `node --test src/utils/widgetDomEvents.test.mjs`
- `npx eslint src/utils/widgetDomEvents.mjs src/utils/widgetDomEvents.test.mjs src/components/chatbot/Chatbot.jsx`
- `npm run test:labels`
- `git diff --check FETCH_HEAD...HEAD`

An explicit production build was not run, per this repository's development guidance.